### PR TITLE
Improve error handling and reporting

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,11 @@
     <body>
         <h1>Image Fourier Transform</h1>
 
+        <div style="display: inline-block; vertical-align: top">
+            Status:
+            <div id="errfield" style="color:red"></div>
+        </div>
+        <br />
         <div>
             <div style="display: inline-block; margin-right: 22px; vertical-align: top">
                 1. Original image


### PR DESCRIPTION
This request improves error reporting a great deal and opens a path toward a more general Cooley-Tukey implementation (one that handles image sizes that are not a power of 2).

I played with this a little the other day and ran into problems when my input image was not a power of 2 in size. It was confusing to receive a JS error about recursion depth in the JS console rather than a more helpful and descriptive message somewhere on the page itself. Due to the poor error reporting I misdiagnosed the issue and went on a wild goose chase, restructuring the algorithm to use an explicit stack (this is not part of the PR).

Better error reporting would have saved me that time.