### PR TITLE
Fixed Flip Issue in Fourier Transform

### DIFF
--- a/js/fourier.js
+++ b/js/fourier.js
@@ -100,23 +100,28 @@ var Fourier = (function() {
   }
   
   function shiftFFT(transform, dims) {
-    return flipRightHalf(
-      halfShiftFFT(
-        halfShiftFFT(
-          transform,
+    return flip(
+        flipRightHalf(
+          halfShiftFFT(
+            halfShiftFFT(
+              transform,
+              dims
+            ),
+            dims
+          ),
           dims
         ),
         dims
-      ),
-      dims
-    );
+      );
   }
 
   function unshiftFFT(transform, dims) {
     return halfShiftFFT(
       halfShiftFFT(
-        flipRightHalf(
-          transform,
+        flipRightHalf(flip(
+            transform,
+            dims
+            ),
           dims
         ),
         dims
@@ -145,6 +150,36 @@ var Fourier = (function() {
     }
     return ret;
   }
+
+
+  function flip(transform, dims){
+    var ret = [];
+  
+    // flip the right half of the image across the x axis
+    var N = dims[1];
+    var M = dims[0];
+    for (var n = 0; n < N; n++) {
+      for (var m = 0; m < M; m++) {
+        if (m>=M/2){
+          if (n==N-2){
+            var $n = 0;
+          } else if (n==N-1){
+            var $n = 1;
+          } else {
+            var $n = N-n-2;
+          };
+        } else {
+          var $n = n;
+        };
+        var idx = $n*dims[0] + m;
+        ret.push(transform[idx]);
+      }
+    }
+  
+    return ret;
+  }
+
+
 
   function flipRightHalf(transform, dims) {
     var ret = [];

--- a/js/main.js
+++ b/js/main.js
@@ -262,6 +262,8 @@ var FourierImageAnalysis = (function() {
           if (error > maxError) maxError = error;
         }
       }
+
+      console.log(minError,maxError);
   
       // draw the pixels
       var currImageData = ctxs[3].getImageData(

--- a/js/main.js
+++ b/js/main.js
@@ -149,6 +149,7 @@ var FourierImageAnalysis = (function() {
       var h_hats = [];
       Fourier.transform(h(), h_hats);
       h_hats = Fourier.shift(h_hats, dims);
+
   
       // get the largest magnitude
       var maxMagnitude = 0;

--- a/js/main.js
+++ b/js/main.js
@@ -264,7 +264,6 @@ var FourierImageAnalysis = (function() {
         }
       }
 
-      console.log(minError,maxError);
   
       // draw the pixels
       var currImageData = ctxs[3].getImageData(


### PR DESCRIPTION
I noticed that the bottom half of the Fourier Transform came out horizontally flipped and shifted by one pixel. This required a change in the overall shifting handler so I created some new functions to handle this. Everything works smoothly now and the Fourier Transform is consistent with other Fourier Transform packages (e.g. numpy.fft in python).